### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM cremuzzi/mpv
 USER root
-RUN apk add git curl grep sed openssl ncurses
+RUN apk add git curl grep sed openssl ncurses coreutils
 WORKDIR /
 RUN git clone https://github.com/pystardust/ani-cli.git
 RUN cp ani-cli/ani-cli /usr/local/bin


### PR DESCRIPTION
Install coreutils in docker container due to inbuilt base64 doesn't support --decode (from ani-cli git)